### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+pipelines/* linguist-vendored


### PR DESCRIPTION
Avoid Meshroom's custom format '.mg' for pipelines to be detected as Modula-3 language in Github's language statistics

![image](https://github.com/alicevision/MeshroomResearch/assets/72821992/9655f228-6b85-46a5-8fba-8a8c4a7eb4c3)
