### PR TITLE
[nodes] Remove all `uid=` from nodes' descriptions

### DIFF
--- a/mrrs/nodes/benchmark/CalibrationComparison.py
+++ b/mrrs/nodes/benchmark/CalibrationComparison.py
@@ -22,7 +22,6 @@ class CalibrationComparison(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.File(
@@ -30,26 +29,23 @@ class CalibrationComparison(desc.Node):
             label='GtSfMData',
             description='Ground Truth SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='metrics',
             label='Metrics',
-            description='Metrics to be used in the comparison',
+            description='Metrics to be used in the comparison.',
             value=['MSECameraCenter'],
             values=['MSECameraCenter','AngleBetweenRotations','MSEFocal', 'MSEPrincipalPoint', 'validCams'],
             exclusive=False,
-            uid=[0],
             joinChar=',',
         ),
 
          desc.StringParam(
             name='csv_name',
             label='CsvName',
-            description='Name for the csv file to be used',
+            description='Name for the csv file to be used.',
             value="calibration_comparison.csv",
-            uid=[0]
         ),
 
         desc.ChoiceParam(
@@ -59,7 +55,6 @@ class CalibrationComparison(desc.Node):
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -69,14 +64,12 @@ class CalibrationComparison(desc.Node):
             label='Output Folder',
             description='Output folder for generated results.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='outputCsv',
             label='Output Csv',
             description='Output file to generated results.',
             value=lambda attr: os.path.join(desc.Node.internalFolder, attr.node.csv_name.value),
-            uid=[],
         )
     ]
 

--- a/mrrs/nodes/benchmark/CleanMesh.py
+++ b/mrrs/nodes/benchmark/CleanMesh.py
@@ -20,23 +20,20 @@ class CleanMesh(CondaNode):
             label='Input Mesh',
             description='',
             value='',
-            uid=[0],
             ),
         desc.File(
             name="face_index_images_folder",
             label='Faces Index Images',
             description='',
             value='',
-            uid=[0],
             ),
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
             group=""
         ),
     ]
@@ -47,7 +44,6 @@ class CleanMesh(CondaNode):
             label="Ouput Mesh",
             description="",
             value=os.path.join(desc.Node.internalFolder, "cleaned_mesh.ply"),
-            uid=[],
             ),
     ]
 

--- a/mrrs/nodes/benchmark/DepthMapComparison.py
+++ b/mrrs/nodes/benchmark/DepthMapComparison.py
@@ -27,33 +27,29 @@ Autorescale may be used otherwise but it is far from ideal.
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.File(
             name="depthMapsFolder",
             label="DepthMaps Folder",
-            description="Input depth maps folder",
+            description="Input depth maps folder.",
             value="",
-            uid=[0],
         ),
 
         desc.File(
             name="depthMapsFolderGT",
             label="GT DepthMaps Folder",
-            description="Input ground truth depth maps folder",
+            description="Input ground truth depth maps folder.",
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='metrics',
             label='Metrics',
-            description='Metrics to be used in the comparison',
+            description='Metrics to be used in the comparison.',
             value=['RMSE', 'MAE', 'validity_ratio'],
             values=['RMSE', 'MAE', 'validity_ratio'],
             exclusive=False,
-            uid=[0],
             joinChar=',',
         ),
 
@@ -62,7 +58,6 @@ Autorescale may be used otherwise but it is far from ideal.
             label='Auto Rescale',
             description='''Will attempt to find a scale factor between GT depth maps and estimated depth maps. To be used when the depth maps have not been estimated from the same camera coordinate system.''',
             value=False,
-            uid=[0],
         ),
 
         desc.StringParam(
@@ -70,25 +65,22 @@ Autorescale may be used otherwise but it is far from ideal.
             label='Mask Value',
             description='''If this is not None, will mask the pixels with value bellow this (in gt and estimated).''',
             value='0',
-            uid=[0],
         ),
 
         desc.StringParam(
             name='csv_name',
             label='CsvName',
-            description='Name for the csv file to be used',
+            description='Name for the csv file to be used.',
             value="depth_map_comparison.csv",
-            uid=[0]
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -98,14 +90,12 @@ Autorescale may be used otherwise but it is far from ideal.
             label='Output',
             description='Output folder for generated results.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='outputCsv',
             label='Output Csv',
             description='Output file to generated results.',
             value=lambda attr: os.path.join(desc.Node.internalFolder, attr.node.csv_name.value),
-            uid=[],
         )
     ]
 

--- a/mrrs/nodes/benchmark/LoadDataset.py
+++ b/mrrs/nodes/benchmark/LoadDataset.py
@@ -24,28 +24,25 @@ class LoadDataset(desc.Node):
         desc.File(
             name="sfmData",
             label="sfmData",
-            description="Input sfmData",
+            description="Input SfMData.",
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='datasetType',
             label='Dataset Type',
-            description='''Dataset type''',
+            description='''Dataset type.''',
             value='blendedMVG',
             values=['blendedMVG', 'DTU', 'ETH3D', 'baptiste', 'alab', 'NERF'],
             exclusive=True,
-            uid=[0],
         ),
 
         desc.IntParam(
             name='initSfmLandmarksVertices',
             label='Init Landmarks Vertices',
-            description='''Will initalise sfmLandmarks by sampling points on mesh. 0 to deactivate''',
+            description='''Will initalise sfmLandmarks by sampling points on mesh. 0 to deactivate.''',
             value=1,
             range=(0, 1000000000, 1),
-            uid=[0],
             advanced=True
         ),
         
@@ -53,29 +50,26 @@ class LoadDataset(desc.Node):
         desc.BoolParam(
             name='initMasks',
             label='Init Masks',
-            description='''If no masks in dataset, will initialise the masks using the values from the depth map (<=0) or the images (alpha<=0)''',
+            description='''If no masks in dataset, will initialise the masks using the values from the depth map (<=0) or the images (alpha<=0).''',
             value=True,
-            uid=[0],
             advanced=True
         ),
 
         desc.BoolParam(
             name='landMarksProj',
             label='Landmarks Projections',
-            description='''Will display point cloud or landmarks projection''',
+            description='''Will display point cloud or landmarks projection.''',
             value=False,
-            uid=[0],
             advanced=True
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
             advanced=True
         ),
     ]
@@ -84,17 +78,15 @@ class LoadDataset(desc.Node):
         desc.File(
             name='outputSfMData',
             label='SfM Data',
-            description='Path to the output sfmdata file',
+            description='Path to the output sfmdata file.',
             value=desc.Node.internalFolder + 'sfm.sfm',
-            uid=[],
         ),
 
         desc.File(
             name='depthMapsFolder',
             label='Depth map folder',
-            description='Output folder for loaded depth maps',
+            description='Output folder for loaded depth maps.',
             value=os.path.join(desc.Node.internalFolder, 'depth_maps'),
-            uid=[],
             # enabled=lambda attr: (attr.node.datasetType.value=='blendedMVG'), #FIXME: does not work!! doesnt actually hides in the node
         ),
 
@@ -104,7 +96,6 @@ class LoadDataset(desc.Node):
             description='Loaded mesh.',
             value=os.path.join(desc.Node.internalFolder, 'mesh.ply'),
             # enabled=lambda attr: (attr.node.datasetType.value=='DTU'),
-            uid=[],
         ),
 
         desc.File(
@@ -112,7 +103,6 @@ class LoadDataset(desc.Node):
             label='Mask Folder',
             description='Image mask folder. The mask describes the visibility of the object to be observed, on each view.',
             value=os.path.join(desc.Node.internalFolder,'masks'),
-            uid=[],
             # enabled=lambda attr: (attr.node.datasetType.value=='DTU'),
         ),
 
@@ -124,7 +114,6 @@ class LoadDataset(desc.Node):
             semantic='image',
             value=os.path.join(desc.Node.internalFolder,
                                'depth_maps', '<VIEW_ID>_depthMap.exr'),
-            uid=[],
             advanced=True,
             visible=False
         ),
@@ -132,11 +121,10 @@ class LoadDataset(desc.Node):
         desc.File(
             name='masksDisplay',
             label='MasksDisplay',
-            description='Generated masks',
+            description='Generated masks.',
             semantic='image',
             value=os.path.join(desc.Node.internalFolder,
                                'masks', '<VIEW_ID>.png'),
-            uid=[],
             advanced=True,
             visible=False
         ),
@@ -144,11 +132,10 @@ class LoadDataset(desc.Node):
         desc.File(
             name='landMarksProjDisplay',
             label='landMarksProjDisplay',
-            description='Generated images for landmarl projection',
+            description='Generated images for landmarl projection.',
             semantic='image',
             value=os.path.join(desc.Node.internalFolder,
                                'lm_projs', '<VIEW_ID>.png'),
-            uid=[],
             advanced=True,
             enabled=lambda attr: attr.node.landMarksProj.value,
             visible=False
@@ -161,7 +148,6 @@ class LoadDataset(desc.Node):
             semantic='3D',
             value=os.path.join(desc.Node.internalFolder,
                                'mesh_display.ply'),
-            uid=[],
             advanced=True,
             visible=False
         ),

--- a/mrrs/nodes/benchmark/MeshComparison.py
+++ b/mrrs/nodes/benchmark/MeshComparison.py
@@ -23,7 +23,6 @@ class MeshcomparisonBaptiste(CondaNode):
             label='Input Mesh',
             description='''''',
             value='',
-            uid=[0],
             ),
 
         desc.File(
@@ -31,27 +30,24 @@ class MeshcomparisonBaptiste(CondaNode):
             label='GroundTruthMesh',
             description='''''',
             value='',
-            uid=[0],
             ),
 
         desc.ChoiceParam(
             name='mode',
             label='Mode',
-            description='''Chose mesh or point cloud''',
+            description='''Choose mesh or point cloud.''',
             value='mesh',
             values=['mesh', 'pcd'],
             exclusive=True,
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
             group=""
         ),
     ]
@@ -62,7 +58,6 @@ class MeshcomparisonBaptiste(CondaNode):
             label='Output Directory',
             description='''''',
             value=desc.Node.internalFolder,
-            uid=[],
             ),
 
             desc.File(
@@ -70,7 +65,6 @@ class MeshcomparisonBaptiste(CondaNode):
             label='Distance Mesh to GT',
             description='''''',
             value=os.path.join(desc.Node.internalFolder, "vis_data2gt.pc.ply"),
-            uid=[],
             semantic="3D",
             group='',
             ),
@@ -80,7 +74,6 @@ class MeshcomparisonBaptiste(CondaNode):
             label='Distance GT to Mesg',
             description='''''',
             value=os.path.join(desc.Node.internalFolder, "vis_gt2data.pc.ply"),
-            uid=[],
             semantic="3D",
             group='',
             ),

--- a/mrrs/nodes/colmap/AutomaticReconstructor.py
+++ b/mrrs/nodes/colmap/AutomaticReconstructor.py
@@ -18,7 +18,6 @@ class ColmapAutomaticReconstructor(desc.CommandLineNode):
             label='Image Directory',
             description='''Path to images.''',
             value='',
-            uid=[0],
         ),
 
     ]
@@ -30,14 +29,12 @@ class ColmapAutomaticReconstructor(desc.CommandLineNode):
             label='Output Folder',
             description='''Output Folder.''',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='output_pc',
             label='Output point cloud',
-            description='''Output point cloud''',
+            description='''Output point cloud.''',
             value=os.path.join(desc.Node.internalFolder, 'dense\\0\\fused.ply'),
-            uid=[],
             group='',
         ),
     ]

--- a/mrrs/nodes/colmap/Colmap2MeshroomSfmConvertions.py
+++ b/mrrs/nodes/colmap/Colmap2MeshroomSfmConvertions.py
@@ -238,32 +238,28 @@ class Colmap2MeshroomSfmConvertion(desc.Node):
         desc.File(
             name='input',
             label='Input',
-            description='Input sparse folder',
+            description='Input sparse folder.',
             value='',
-            uid=[0],
         ),
         desc.File(
             name='inputSfm',
             label='InputSfm',
-            description='Input sfm from cameraInit',
+            description='Input sfm from cameraInit.',
             value='',
-            uid=[0],
         ),
         desc.File(
             name='imageFolder',
             label='ImageFolder',
-            description='Input image folder (needed if you dont use a SfM)',
+            description='Input image folder (needed if you dont use a SfM).',
             value='',
-            uid=[0],
         ),
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='verbosity level (fatal, error, warning, info, debug, trace).',
+            description='Verbosity level (fatal, error, warning, info, debug, trace).',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -273,7 +269,6 @@ class Colmap2MeshroomSfmConvertion(desc.Node):
             label='Output Sfm',
             description='Path to the output SfM file.',
             value=os.path.join(desc.Node.internalFolder, "sfmdata.sfm"),
-            uid=[],
             ),
     ]
 

--- a/mrrs/nodes/colmap/DelaunayMesher.py
+++ b/mrrs/nodes/colmap/DelaunayMesher.py
@@ -20,9 +20,8 @@ class DelaunayMesher(desc.CommandLineNode):
         desc.File(
             name='input_path',
             label='Input path',
-            description='Path to either the dense workspace folder',
+            description='Path to either the dense workspace folder.',
             value='',
-            uid=[0],
         ),
     ]
 
@@ -30,9 +29,8 @@ class DelaunayMesher(desc.CommandLineNode):
         desc.File(
             name='output_path',
             label='OutputPath',
-            description='Output path',
+            description='Output path.',
             value=os.path.join(desc.Node.internalFolder, "mesh_delaunay.ply"),
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/colmap/FeatureExtraction.py
+++ b/mrrs/nodes/colmap/FeatureExtraction.py
@@ -20,25 +20,22 @@ class ColmapFeatureExtraction(desc.CommandLineNode):
         #     label='Images Directory',
         #     description='''Path to images directory.''',
         #     value="",
-        #     uid=[0],
         # ), #FIXME: issue there, cannot be updated by node for next nodes, if uid !=0 then it changes the uid without notifuying next nodes
         #dirty fix: copy images to this folder in outputss
 
         desc.File(
             name='input_sfm',
             label='Input Sfm',
-            description='''Extracts the image path from an input sfm''',
+            description='''Extracts the image path from an input SfM.''',
             value='',
-            uid=[0],
             group=''
         ),
 
         desc.BoolParam(
             name="use_gpu",
             label = "Use GPU",
-            description='''Will use GPU for feature extraction''',
+            description='''Will use GPU for feature extraction.''',
             value=False,
-            uid=[0],
             group='',
         ),
 
@@ -51,7 +48,6 @@ class ColmapFeatureExtraction(desc.CommandLineNode):
         #     values=['PINHOLE', 'SIMPLE_PINHOLE', 'RADIAL', 'SIMPLE_RADIAL', 'OPENCV', 'FULL_OPENCV',
         #             'SIMPLE_RADIAL_FISHEYE', 'RADIAL_FISHEYE', 'OPENCV_FISHEYE', 'FOV', 'THIN_PRISM_FISHEYE'],
         #     exclusive=True,
-        #     uid=[],
         # ),
 
         desc.BoolParam(
@@ -59,7 +55,6 @@ class ColmapFeatureExtraction(desc.CommandLineNode):
             label='SingleCamera',
             description='''If the scene has be shot with a single camera.''',
             value=False,
-            uid=[0],
             group=''
         ),
     ]
@@ -70,21 +65,18 @@ class ColmapFeatureExtraction(desc.CommandLineNode):
             label='Sensor Database',
             description='''Camera sensor width database path.''',
             value=os.path.join(desc.Node.internalFolder, "colmap_database.db"),
-            uid=[],
         ),
         desc.File(
             name='image_list_path',
             label='Used Images',
             description='''Used images (if from .sfm)''',
             value=os.path.join(desc.Node.internalFolder, "used_images.txt"),
-            uid=[],
         ),
         desc.File(
             name='image_path',
             label='Images Directory',
             description='''Path to images directory.''',
             value=os.path.join(desc.Node.internalFolder, "images"),
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/colmap/FeatureMatching.py
+++ b/mrrs/nodes/colmap/FeatureMatching.py
@@ -17,17 +17,15 @@ class ColmapFeatureMatching(desc.CommandLineNode):
         desc.File(
             name='input_database_path',
             label='InputDatabase',
-            description='Input database path',
+            description='Input database path.',
             value='',
-            uid=[0],
             group='',
         ),
         desc.BoolParam(
             name="use_gpu",
             label = "Use GPU",
-            description='''Will use GPU for feature extraction''',
+            description='''Will use GPU for feature extraction.''',
             value=False,
-            uid=[0],
             group='',
         )
     ]
@@ -36,10 +34,8 @@ class ColmapFeatureMatching(desc.CommandLineNode):
         desc.File(
             name='database_path',
             label='OutputDatabasePath',
-            description='Output database path',
+            description='Output database path.',
             value=os.path.join(desc.Node.internalFolder, 'colmap_database_matches.db'),
-            uid=[],
-
         ),
     ]
 

--- a/mrrs/nodes/colmap/ImageUndistorder.py
+++ b/mrrs/nodes/colmap/ImageUndistorder.py
@@ -26,7 +26,6 @@ class ColmapImageUndistorder(desc.CommandLineNode):
             label='Image Directory',
             description='''Path to images.''',
             value='',
-            uid=[0],
         ),
 
         desc.File(
@@ -34,7 +33,6 @@ class ColmapImageUndistorder(desc.CommandLineNode):
             label='Input Directory',
             description='''Path to input directory (from matcher).''',
             value='',
-            uid=[0],
         ),
 
         #FIXME: this does not update the files!
@@ -43,7 +41,6 @@ class ColmapImageUndistorder(desc.CommandLineNode):
         #     label='Max Image Size',
         #     description='''Used to downsample images''',
         #     value='2000',
-        #     uid=[0],
         # ),
 
     ]
@@ -54,7 +51,6 @@ class ColmapImageUndistorder(desc.CommandLineNode):
             label='Ouptut Path',
             description='''Output path path.''',
             value=os.path.join(desc.Node.internalFolder),
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/colmap/ImportColmapDepthMaps.py
+++ b/mrrs/nodes/colmap/ImportColmapDepthMaps.py
@@ -45,28 +45,25 @@ class ImportColmapDepthMaps(desc.Node):
         desc.File(
             name="input",
             label="Input",
-            description="COLMAP Dense folder in workspace",
+            description="COLMAP Dense folder in workspace.",
             value="",
-            uid=[0],
         ),
 
         desc.File(
             name="inputSfm",
             label="InputSfm",
-            description="Input sfm data, used to match the views",
+            description="Input SfM data, used to match the views.",
             value="",
-            uid=[0],
         ),
 
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -74,9 +71,8 @@ class ImportColmapDepthMaps(desc.Node):
         desc.File(
             name='depthMapFolder',
             label='Depth maps folder',
-            description='Generated depth maps folder',
+            description='Generated depth maps folder.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         #for viz
         desc.File(
@@ -85,7 +81,6 @@ class ImportColmapDepthMaps(desc.Node):
             description='Generated depth maps.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap.exr',
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/colmap/Mapper.py
+++ b/mrrs/nodes/colmap/Mapper.py
@@ -89,9 +89,8 @@ class ColmapMapper(desc.CommandLineNode):
         desc.File(
             name='input_database_path',
             label='InputDatabase',
-            description='Input database path',
+            description='Input database path.',
             value='',
-            uid=[0],
             group='',
         ),
         desc.File(
@@ -99,7 +98,6 @@ class ColmapMapper(desc.CommandLineNode):
             label='Image Directory',
             description='''Path to images.''',
             value='',
-            uid=[0],
         ),
     ]
 
@@ -107,16 +105,14 @@ class ColmapMapper(desc.CommandLineNode):
         desc.File(
             name='output_path',
             label='BaseOutputPath',
-            description='Base Output path',
+            description='Base Output path.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='output_path0',
             label='OutputPath0',
-            description='Output path 0',
+            description='Output path 0.',
             value=os.path.join(desc.Node.internalFolder, "0"),
-            uid=[],
             group=""
         ),
         # desc.File(
@@ -124,7 +120,6 @@ class ColmapMapper(desc.CommandLineNode):
         #     label='Cameras',
         #     description='Ouptut camera file',
         #     value=os.path.join(desc.Node.internalFolder, "0", "cameras.bin"),
-        #     uid=[],
         #     group=""
         # ),
         desc.File(
@@ -132,7 +127,6 @@ class ColmapMapper(desc.CommandLineNode):
             label='OutputDatabasePath',
             description='Output database path',
             value=os.path.join(desc.Node.internalFolder, 'colmap_database_mapper.db'),
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/colmap/Meshroom2ColmapSfmConvertions.py
+++ b/mrrs/nodes/colmap/Meshroom2ColmapSfmConvertions.py
@@ -22,28 +22,25 @@ class Meshroom2ColmapSfmConvertions(desc.CommandLineNode):
             label='Input',
             description='SfMData file.',
             value='',
-            uid=[0],
             group=""
         ),
 
         desc.IntParam(
             name='maxImageSize',
             label='Max Image Width',
-            description='''Used to downsample images''',
+            description='''Used to downsample images.''',
             value=0,
             range=(0, 1000000000, 1),
-            uid=[0],
             group=""
             ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='verbosity level (fatal, error, warning, info, debug, trace).',
+            description='Verbosity level (fatal, error, warning, info, debug, trace).',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -51,9 +48,8 @@ class Meshroom2ColmapSfmConvertions(desc.CommandLineNode):
         desc.File(
             name='preparedSfm',#ugly hack to have an input that can change
             label='preparedSfm',
-            description='SfMData file prepared for colmap',
+            description='SfMData file prepared for colmap.',
             value=os.path.join(desc.Node.internalFolder, "prepared_sfm.json"),
-            uid=[],
             advanced=True,
         ),
         desc.File(
@@ -61,14 +57,12 @@ class Meshroom2ColmapSfmConvertions(desc.CommandLineNode):
             label='Output Folder',
             description='Path to the output SfM Data file.',
             value=desc.Node.internalFolder,
-            uid=[],
             ),
         desc.File(
             name='imageDirectory',
             label='Image Directory',
             description='',
             value=os.path.join(desc.Node.internalFolder, "images"),
-            uid=[],
             group=""
             ),
         desc.File(
@@ -76,7 +70,6 @@ class Meshroom2ColmapSfmConvertions(desc.CommandLineNode):
             label='Sparse Directory',
             description='',
             value=os.path.join(desc.Node.internalFolder, "sparse"),
-            uid=[],
             group=""
             ),
     ]

--- a/mrrs/nodes/colmap/PatchMatchStereo.py
+++ b/mrrs/nodes/colmap/PatchMatchStereo.py
@@ -22,9 +22,8 @@ class PatchMatchStereo(desc.CommandLineNode):
         desc.File(
             name='input_folder',
             label='Input Folder',
-            description='Input Folder (output of undisto)',
+            description='Input Folder (output of undisto).',
             value='',
-            uid=[0],
             group=""
         ),
     ]
@@ -33,9 +32,8 @@ class PatchMatchStereo(desc.CommandLineNode):
         desc.File(
             name='workspace_path',
             label='OutputPath',
-            description='Output path',
+            description='Output path.',
             value=os.path.join(desc.Node.internalFolder, "workspace"),
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/colmap/PoissonMesher.py
+++ b/mrrs/nodes/colmap/PoissonMesher.py
@@ -23,17 +23,15 @@ class PoissonMesher(desc.CommandLineNode):
         desc.File(
             name='input_path',
             label='Input Point Cloud',
-            description='Input Point Cloud',
+            description='Input Point Cloud.',
             value='',
-            uid=[0],
         ),
         desc.FloatParam(
             name='trim',
             label='trim',
-            description='Poisson Meshing Triming parameters',
+            description='Poisson Meshing Triming parameters.',
             value=0.0,
             range=(0.0, 100.0, 1.0),
-            uid=[0],
             ),
     ]
 
@@ -41,9 +39,8 @@ class PoissonMesher(desc.CommandLineNode):
         desc.File(
             name='output_mesh',
             label='OutputMesh',
-            description='Output mesh',
+            description='Output mesh.',
             value=os.path.join(desc.Node.internalFolder, "mesh_poisson.ply"),
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/colmap/StereoFusion.py
+++ b/mrrs/nodes/colmap/StereoFusion.py
@@ -23,9 +23,8 @@ class StereoFusion(desc.CommandLineNode):
         desc.File(
             name='input_folder',
             label='Input Folder',
-            description='Input Workspace Folder (output of patch match)',
+            description='Input Workspace Folder (output of patch match).',
             value='',
-            uid=[0],
             group=""
         ),
 
@@ -35,20 +34,17 @@ class StereoFusion(desc.CommandLineNode):
         desc.File(
             name='output_path',
             label='OutputPath',
-            description='Output point cloud path',
+            description='Output point cloud path.',
             value=os.path.join(desc.Node.internalFolder,  "workspace", "fused.ply"),
-            uid=[],
         ),
 
 
         desc.File(
             name='workspace_path',
             label='Output Workspace Folder',
-            description='Output workspace path',
+            description='Output workspace path.',
             value=os.path.join(desc.Node.internalFolder, "workspace"),
-            uid=[],
         ),
-
     ]
 
     def processChunk(self, chunk):

--- a/mrrs/nodes/depth_map/VizMVSNet.py
+++ b/mrrs/nodes/depth_map/VizMVSNet.py
@@ -48,60 +48,54 @@ class VizMVSNet(CondaNode):
         return ENV_FILE
     
     inputs = [
-            desc.File(
-                name="inputSfMData",
-                label="SfMData",
-                description="Input SfMData file.",
-                value="",
-                uid=[0],
-                group=""
-            ),
-            desc.File(
-                name="viewPairs",
-                label="viewPairs",
-                description="View pairs",
-                value="",
-                uid=[0],
-            ),
+        desc.File(
+            name="inputSfMData",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+            group=""
+        ),
+        desc.File(
+            name="viewPairs",
+            label="viewPairs",
+            description="View pairs.",
+            value="",
+        ),
 
-            desc.FloatParam(
-                name="minD",
-                label="min depth",
-                description="Min Depth",
-                value=0.0,
-                range=(0.0, 2048.0, 1.0),
-                uid=[0],
-                group=""
-            ),
-            desc.IntParam(
-                name="stepsD",
-                label="depth steps",
-                description="depth steps",
-                value=256,
-                range=(0, 2048, 1),
-                uid=[0],
-                group=""
-            ),
-            desc.FloatParam(
-                name="maxD",
-                label="max depth",
-                description="Max Depth",
-                value=10.0,
-                range=(0.0, 2048.0, 1.0),
-                uid=[0],
-                group=""
-            ),
-        
-            desc.ChoiceParam(
-                name='verboseLevel',
-                label='Verbose Level',
-                description='''verbosity level (fatal, error, warning, info, debug, trace).''',
-                value='info',
-                values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
-                exclusive=True,
-                uid=[0],
-                )
-            ]
+        desc.FloatParam(
+            name="minD",
+            label="min depth",
+            description="Min Depth.",
+            value=0.0,
+            range=(0.0, 2048.0, 1.0),
+            group=""
+        ),
+        desc.IntParam(
+            name="stepsD",
+            label="Depth Steps",
+            description="Depth steps.",
+            value=256,
+            range=(0, 2048, 1),
+            group=""
+        ),
+        desc.FloatParam(
+            name="maxD",
+            label="Max Depth",
+            description="Max Depth.",
+            value=10.0,
+            range=(0.0, 2048.0, 1.0),
+            group=""
+        ),
+    
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+        )
+    ]
 
     outputs = [
         desc.File(
@@ -109,15 +103,13 @@ class VizMVSNet(CondaNode):
             label="Output Folder",
             description="Path to a folder in which the computed results are stored.",
             value=desc.Node.internalFolder,
-            uid=[],
         ),
 
         desc.StringParam(
             name="sizeParam",
             label="sizeParam",
-            description="sizeParam",
+            description="Size.",
             value="",
-            uid=[],
         ),
 
         desc.File(
@@ -126,7 +118,6 @@ class VizMVSNet(CondaNode):
             description='Generated depth maps.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap.exr',
-            uid=[],
             group='',
             )   
     ]

--- a/mrrs/nodes/nerf/nerfstudio.py
+++ b/mrrs/nodes/nerf/nerfstudio.py
@@ -126,61 +126,55 @@ class NeRFStudio(CondaNode):
     env_file = ENV_FILE
 
     inputs = [
-            desc.File(
-                name="inputSfMData",
-                label="SfMData",
-                description="Input SfMData file.",
-                value="",
-                uid=[0],
-                group=""
-            ),
-            desc.ChoiceParam(
-                name='method',
-                label='Method',
-                description='Method',
-                value='nerfacto',
-                values=['dnerf', 'generfacto', 'instant-ngp', 'instant-ngp-bounded', 'mipnerf', 'nerfacto', 'nerfacto-big', 'nerfacto-huge', 'neus', 'neus-facto', 'splatfacto', 'splatfacto-big', 'tensorf', 'vanilla-nerf'],
-                exclusive=True,
-                uid=[0],
-                group=""
-            ),
-            desc.IntParam(
-                name='max-num-iterations',
-                label='Number of Iterations',
-                description='Maximum number of iterations to run.',
-                value=30000,
-                range=(5000, 100000, 5000),
-                uid=[0],
-            ),
-            # desc.BoolParam(
-            #     name='pipeline.model.predict-normals',
-            #     label='Predict Normals',
-            #     description='Predict normals.',
-            #     value=True,
-            #     uid=[0],
-            #     enabled=lambda attr: (attr.node.method.value=='nerfacto' or attr.node.method.value=='nerfacto-big' or attr.node.method.value=='nerfacto-huge'),
-            # ),
-            desc.ChoiceParam(
-                name='verboseLevel',
-                label='Verbose Level',
-                description='''verbosity level (fatal, error, warning, info, debug, trace).''',
-                value='info',
-                values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
-                exclusive=True,
-                uid=[0],
-                group="",
-                )
-            ]
+        desc.File(
+            name="inputSfMData",
+            label="SfMData",
+            description="Input SfMData file.",
+            value="",
+            group=""
+        ),
+        desc.ChoiceParam(
+            name='method',
+            label='Method',
+            description='Method.',
+            value='nerfacto',
+            values=['dnerf', 'generfacto', 'instant-ngp', 'instant-ngp-bounded', 'mipnerf', 'nerfacto', 'nerfacto-big', 'nerfacto-huge', 'neus', 'neus-facto', 'splatfacto', 'splatfacto-big', 'tensorf', 'vanilla-nerf'],
+            exclusive=True,
+            group=""
+        ),
+        desc.IntParam(
+            name='max-num-iterations',
+            label='Number of Iterations',
+            description='Maximum number of iterations to run.',
+            value=30000,
+            range=(5000, 100000, 5000),
+        ),
+        # desc.BoolParam(
+        #     name='pipeline.model.predict-normals',
+        #     label='Predict Normals',
+        #     description='Predict normals.',
+        #     value=True,
+        #     enabled=lambda attr: (attr.node.method.value=='nerfacto' or attr.node.method.value=='nerfacto-big' or attr.node.method.value=='nerfacto-huge'),
+        # ),
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+            group="",
+        )
+    ]
 
     outputs = [
-            desc.File(
-                name='output',
-                label='Output',
-                description='Output folder.',
-                value=desc.Node.internalFolder,
-                uid=[],
-                group="",
-            ),
+        desc.File(
+            name='output',
+            label='Output',
+            description='Output folder.',
+            value=desc.Node.internalFolder,
+            group="",
+        ),
     ]
 
     def processChunk(self, chunk):

--- a/mrrs/nodes/nerf/nerfstudio_export.py
+++ b/mrrs/nodes/nerf/nerfstudio_export.py
@@ -16,121 +16,109 @@ class NeRFStudioExport(CondaNode):
     env_file = ENV_FILE
 
     inputs = [
-            desc.File(
-                name="input",
-                label="Input",
-                description="Input folder.",
-                value="",
-                uid=[0],
-                group=""
-            ),
-            desc.ChoiceParam(
-                name='method',
-                label='Method',
-                description='Method to export the NeRF model.',
-                value='poisson',
-                values=['pointcloud', 'tsdf', 'poisson', 'marching-cubes', 'cameras', 'gaussian-splat'],
-                exclusive=True,
-                uid=[0],
-                group=""
-            ),
+        desc.File(
+            name="input",
+            label="Input",
+            description="Input folder.",
+            value="",
+            group=""
+        ),
+        desc.ChoiceParam(
+            name='method',
+            label='Method',
+            description='Method to export the NeRF model.',
+            value='poisson',
+            values=['pointcloud', 'tsdf', 'poisson', 'marching-cubes', 'cameras', 'gaussian-splat'],
+            exclusive=True,
+            group=""
+        ),
 
-            # PointCloud Options
-            desc.IntParam(
-                name='numPoints',
-                label='Number of Points',
-                description='Number of points to generate. May result in less if outlier removal is used.',
-                value=1000000,
-                range=(1000, 10000000, 1000),
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
-            ),
-            desc.BoolParam(
-                name='removeOutliers',
-                label='Remove Outliers',
-                description='Remove outliers from the point cloud.',
-                value=True,
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
-            ),
-            desc.BoolParam(
-                name='reorientNormals',
-                label='Reorient Normals',
-                description='Reorient point cloud normals based on view direction.',
-                value=True,
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
-            ),
-            desc.ChoiceParam(
-                name='normalMethod',
-                label='Normal Method',
-                description='Method to estimate normals with.',
-                value='model_output',
-                values=['open3d', 'model_output'],
-                exclusive=True,
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
-            ),
+        # PointCloud Options
+        desc.IntParam(
+            name='numPoints',
+            label='Number of Points',
+            description='Number of points to generate. May result in less if outlier removal is used.',
+            value=1000000,
+            range=(1000, 10000000, 1000),
+            enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
+        ),
+        desc.BoolParam(
+            name='removeOutliers',
+            label='Remove Outliers',
+            description='Remove outliers from the point cloud.',
+            value=True,
+            enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
+        ),
+        desc.BoolParam(
+            name='reorientNormals',
+            label='Reorient Normals',
+            description='Reorient point cloud normals based on view direction.',
+            value=True,
+            enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
+        ),
+        desc.ChoiceParam(
+            name='normalMethod',
+            label='Normal Method',
+            description='Method to estimate normals with.',
+            value='model_output',
+            values=['open3d', 'model_output'],
+            exclusive=True,
+            enabled=lambda attr: (attr.node.method.value=='pointcloud') or (attr.node.method.value=='poisson'),
+        ),
 
-            # TSDF Options
-            desc.IntParam(
-                name='downscaleFactor',
-                label='Downscale Factor',
-                description='Downscale the images starting from the resolution used for training.',
-                value=1,
-                range=(1, 8, 1),
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='tsdf'),
-            ),
-            desc.IntParam(
-                name='resolution',
-                label='Resolution',
-                description='Resolution of the mesh.',
-                value=256,
-                range=(256, 2048, 256),
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='tsdf') or (attr.node.method.value=='marching-cubes'),
-            ),
+        # TSDF Options
+        desc.IntParam(
+            name='downscaleFactor',
+            label='Downscale Factor',
+            description='Downscale the images starting from the resolution used for training.',
+            value=1,
+            range=(1, 8, 1),
+            enabled=lambda attr: (attr.node.method.value=='tsdf'),
+        ),
+        desc.IntParam(
+            name='resolution',
+            label='Resolution',
+            description='Resolution of the mesh.',
+            value=256,
+            range=(256, 2048, 256),
+            enabled=lambda attr: (attr.node.method.value=='tsdf') or (attr.node.method.value=='marching-cubes'),
+        ),
 
-            # Marching Cubes Options
-            desc.FloatParam(
-                name='isosurface-threshold',
-                label='Isosurface Threshold',
-                description='The isosurface threshold for extraction. For SDF based methods the surface is the zero level set.',
-                value=0.0,
-                range=(-1.0, 1.0, 0.01),
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='marching-cubes'),
-            ),
-            desc.BoolParam(
-                name='simplify-mesh',
-                label='Simplify Mesh',
-                description='Simplify the mesh after extraction.',
-                value=False,
-                uid=[0],
-                enabled=lambda attr: (attr.node.method.value=='marching-cubes'),
-            ),
-            
-            desc.ChoiceParam(
-                name='verboseLevel',
-                label='Verbose Level',
-                description='''verbosity level (fatal, error, warning, info, debug, trace).''',
-                value='info',
-                values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
-                exclusive=True,
-                uid=[0],
-                group="",
-                )
-            ]
+        # Marching Cubes Options
+        desc.FloatParam(
+            name='isosurface-threshold',
+            label='Isosurface Threshold',
+            description='The isosurface threshold for extraction. For SDF based methods the surface is the zero level set.',
+            value=0.0,
+            range=(-1.0, 1.0, 0.01),
+            enabled=lambda attr: (attr.node.method.value=='marching-cubes'),
+        ),
+        desc.BoolParam(
+            name='simplify-mesh',
+            label='Simplify Mesh',
+            description='Simplify the mesh after extraction.',
+            value=False,
+            enabled=lambda attr: (attr.node.method.value=='marching-cubes'),
+        ),
+        
+        desc.ChoiceParam(
+            name='verboseLevel',
+            label='Verbose Level',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
+            value='info',
+            values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
+            exclusive=True,
+            group="",
+        )
+    ]
 
     outputs = [
-            desc.File(
-                name='output-dir',
-                label='Output',
-                description='Output folder.',
-                value=desc.Node.internalFolder,
-                uid=[],
-            ),
+        desc.File(
+            name='output-dir',
+            label='Output',
+            description='Output folder.',
+            value=desc.Node.internalFolder,
+        ),
     ]
 
     def processChunk(self, chunk):

--- a/mrrs/nodes/reality_capture/ExportXMP.py
+++ b/mrrs/nodes/reality_capture/ExportXMP.py
@@ -23,29 +23,26 @@ class ExportXMP(desc.Node):
         desc.ChoiceParam(
             name='targetXMP',
             label='target XMP',
-            description='''Target XMP format to be used''',
+            description='''Target XMP format to be used.''',
             value='export_reality_capture',
             values=['export_reality_capture'],
             exclusive=True,
-            uid=[0],
         ),
 
         desc.File(
             name="sfmData",
             label="sfmData",
-            description="Input sfmData",
+            description="Input sfmData.",
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -55,7 +52,6 @@ class ExportXMP(desc.Node):
             label='Output folder',
             description='Path to the XMP folder',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/reality_capture/ImportXMP.py
+++ b/mrrs/nodes/reality_capture/ImportXMP.py
@@ -22,35 +22,31 @@ class ImportXMP(desc.Node):
         desc.File(
             name="sfmData",
             label="sfmData",
-            description="Input sfmData",
+            description="Input sfmData.",
             value="",
-            uid=[0],
         ),
 
         desc.File(
             name="xmpData",
             label="xmpData",
-            description="Input xmpData",
+            description="Input xmpData.",
             value="",
-            uid=[0],
         ),
 
         desc.File(
             name="meshData",
             label="meshData",
-            description="Input mesh",
+            description="Input mesh.",
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -58,9 +54,8 @@ class ImportXMP(desc.Node):
         desc.File(
             name='outputSfMData',
             label='outputSfMData',
-            description='Path to the outputSfMData',
+            description='Path to the outputSfMData.',
             value=os.path.join(desc.Node.internalFolder, "outputSfMData.sfm"),
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/render/CreateTrackingMarkers.py
+++ b/mrrs/nodes/render/CreateTrackingMarkers.py
@@ -166,36 +166,32 @@ class CreateTrackingMarkers(desc.Node):
         desc.File(
             name='sfmData',
             label='SfmData',
-            description='Input sfm file.',
+            description='Input SfM file.',
             value=desc.Node.internalFolder,
-            uid=[0],
         ),
 
         desc.File(
             name='objFile',
             label='3D Object',
-            description='Input obj file to display (optional)',
+            description='Input obj file to display (optional).',
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='track_mode',
             label='Track Mode',
-            description='''Mode to display over the images''',
+            description='''Mode to display over the images.''',
             value='display_track_cones',
             values=['display_track_cones', 'display_track_spheres', 'display_no_tracks'],
             exclusive=True,
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='track_param_sort_mode',
             label='Sorting Mode',
-            description='''Sort Mode to display Track Cones''',
+            description='''Sort Mode to display Track Cones.''',
             value='longest',
             values=['longest', 'scale'],
-            uid=[0],
             enabled=lambda node: node.track_mode.value=='display_track_cones' or node.track_mode.value=='display_track_spheres',
             exclusive=True
         ),
@@ -207,7 +203,6 @@ class CreateTrackingMarkers(desc.Node):
             description=''' ''',
             value=1,
             range=(0, 10000, 1),
-            uid=[0],
             enabled=lambda node: node.track_mode.value=='display_track_cones' or node.track_mode.value=='display_track_spheres'
         ),
 
@@ -217,37 +212,33 @@ class CreateTrackingMarkers(desc.Node):
             description='''Grid size to be used. Will only keep N landmarks per voxel.''',
             value=10,
             range=(0, 10000, 1),
-            uid=[0],
             enabled=lambda node: node.track_mode.value=='display_track_cones' or node.track_mode.value=='display_track_spheres'
         ),
 
         desc.IntParam(
             name='param_min_landmark_per_voxel',
             label='Minimum landmark per voxel',
-            description='''Will only display landmarks if the voxel as this amount of ttal landmarks''',
+            description='''Will only display landmarks if the voxel as this amount of total landmarks.''',
             value=10,
             range=(0, 10000, 1),
-            uid=[0],
             enabled=lambda node: node.track_mode.value=='display_track_cones' or node.track_mode.value=='display_track_spheres'
         ),
 
         desc.BoolParam(
             name="render",
             label = "Generate 2D renders",
-            description='''Will render the markers directly on frames ''',
+            description='''Will render the markers directly on frames.''',
             value=False,
-            uid=[0],
             group='',
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -255,16 +246,14 @@ class CreateTrackingMarkers(desc.Node):
         desc.File(
             name='outputFile',
             label='Output Json',
-            description='Output file to place track info to',
+            description='Output file to place track info to.',
             value=os.path.join(desc.Node.internalFolder, "track_objects.json"),
-            uid=[],
         ),
         desc.File(
             name='outputImages',
             label='Output Images',
             description='Output image regex if any',
             value=os.path.join(desc.Node.internalFolder, "*.png"),
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/render/Render360.py
+++ b/mrrs/nodes/render/Render360.py
@@ -16,16 +16,14 @@ class Render360(desc.CommandLineNode):
         desc.File(
             name='script',
             label='Script',
-            description='Python script to render markers',
+            description='Python script to render markers.',
             value=DEFAULT_RENDER_SCRIPT,
-            uid=[0]
         ),
         desc.File(
             name='objectFile',
             label='objectFile',
-            description='Object File',
+            description='Object File.',
             value='',
-            uid=[0],
         ),
 
         desc.IntParam(
@@ -34,23 +32,20 @@ class Render360(desc.CommandLineNode):
             description='Render steps.',
             value=64,
             range=(0, 1000000, 1),
-            uid=[0],
         ),
     ]
     outputs = [
         desc.File(
             name='outputFolder',
             label='Folder',
-            description='Output folder for generated images',
+            description='Output folder for generated images.',
             value=desc.Node.internalFolder,
-            uid=[]
         ),
 
         desc.File(
             name='outputImages',
             label='outputImages',
-            description='Output  generated images',
+            description='Output generated images.',
             value=os.path.join(desc.Node.internalFolder, "*.png"),
-            uid=[]
         ),
     ]

--- a/mrrs/nodes/render/RenderMesh.py
+++ b/mrrs/nodes/render/RenderMesh.py
@@ -15,49 +15,43 @@ class RenderMesh(desc.CommandLineNode):
         desc.File(
             name='script',
             label='Script',
-            description='Python script to render markers',
+            description='Python script to render markers.',
             value=RENDER_SCRIPT,
-            uid=[0]
         ),
         desc.File(
             name='model',
             label='Model',
-            description='Model to render',
+            description='Model to render.',
             value='',
-            uid=[0]
         ),
         desc.File(
             name='cameras',
             label='SfM Data',
-            description='Views, intrinsincs and estimated poses',
+            description='Views, intrinsincs and estimated poses.',
             value='',
-            uid=[0]
         ),
         desc.ChoiceParam(
             name='renderMode',
             label='Render Mode',
-            description='Rendering mode',
+            description='Rendering mode.',
             values=["MESH", "FACES", "DEPTH"],
             value='MESH',
             exclusive=True,
-            uid=[0]
         ),
     ]
     outputs = [
         desc.File(
             name='output',
             label='OutputFolder',
-            description='Output folder for generated images',
+            description='Output folder for generated images.',
             value=desc.Node.internalFolder,
-            uid=[]
         ),
 
         desc.File(
             name='overlay',
             label='Overlay',
-            description='Rendered views',
+            description='Rendered views.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>.exr',
-            uid=[]
         ),
     ]

--- a/mrrs/nodes/render/RenderOverlay.py
+++ b/mrrs/nodes/render/RenderOverlay.py
@@ -14,48 +14,42 @@ class RenderOverlay(desc.CommandLineNode):
         desc.File(
             name='script',
             label='Script',
-            description='Python script to render markers',
+            description='Python script to render markers.',
             value=DEFAULT_RENDER_SCRIPT,
-            uid=[0]
         ),
         desc.File(
             name='markers',
             label='Markers',
-            description='3D markers to render',
+            description='3D markers to render.',
             value='',
-            uid=[0]
         ),
         desc.FloatParam(
             name='sizeFactor',
             label='Size Factor',
-            description='Marker size factor',
+            description='Marker size factor.',
             value=1.0,
             range=(0.0, 10.0, 0.1),
-            uid=[0]
         ),
         desc.File(
             name='sfmData',
             label='SfM Data',
-            description='Views, intrinsincs and estimated poses',
+            description='Views, intrinsincs and estimated poses.',
             value='',
-            uid=[0]
         ),
     ]
     outputs = [
         desc.File(
             name='outputFolder',
             label='Folder',
-            description='Output folder for generated images',
+            description='Output folder for generated images.',
             value=desc.Node.internalFolder,
-            uid=[]
         ),
 
         desc.File(
             name='overlay',
             label='Overlay',
-            description='Rendered views with markers overlay',
+            description='Rendered views with markers overlay.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>.jpg',
-            uid=[]
         ),
     ]

--- a/mrrs/nodes/render/SyntheticDataset.py
+++ b/mrrs/nodes/render/SyntheticDataset.py
@@ -29,84 +29,73 @@ class SyntheticDataset(desc.InitNode, desc.CommandLineNode):
         desc.File(
             name='blenderFile',
             label='Blender File',
-            description='Blender file containing the synthetic scene and camera',
+            description='Blender file containing the synthetic scene and camera.',
             value='',
-            uid=[0]
         ),
         desc.File(
             name='script',
             label='Script',
-            description='Python script to extract ground truth data',
+            description='Python script to extract ground truth data.',
             value='MeshroomResearch/mrrs/blender/extract_ground_truth.py',
-            uid=[0]
         ),
         desc.File(
             name='imagesFolder',
             label='Images Folder',
-            description='Folder containing the images rendered from the Blender file',
+            description='Folder containing the images rendered from the Blender file.',
             value='',
-            uid=[0]
         ),
         desc.StringParam(
             name='sceneName',
             label='Scene Name',
-            description='Name of the 3D scene in Blender',
+            description='Name of the 3D scene in Blender.',
             value='Scene',
-            uid=[0]
         ),
         desc.StringParam(
             name='cameraName',
             label='Camera Name',
-            description='Name of the camera in Blender',
+            description='Name of the camera in Blender.',
             value='Camera',
-            uid=[0]
         ),
         desc.IntParam(
             name='frameStart',
             label='Frame Start',
-            description='First frame',
+            description='First frame.',
             value=0,
             range=(0,1000,1),
-            uid=[0]
         ),
         desc.IntParam(
             name='frameEnd',
             label='Frame End',
-            description='Last Frame (excluded)',
+            description='Last Frame (excluded).',
             value=100,
             range=(0,1000,1),
-            uid=[0]
         ),
         desc.IntParam(
             name='frameStep',
             label='Frame Step',
-            description='Step for downsampling the dataset',
+            description='Step for downsampling the dataset.',
             value=1,
             range=(1,100,1),
-            uid=[0]
         ),
     ]
     outputs = [
         desc.File(
             name='outputFolder',
             label='Folder',
-            description='Output folder for generated ground truth files',
+            description='Output folder for generated ground truth files.',
             value=desc.Node.internalFolder,
-            uid=[]
         ),
         desc.File(
             name='fakeCameraInit',
             label='Fake Camera Init',
-            description='Sfm file containing the ground truth views and intrinsics (without poses)',
-            value=desc.Node.internalFolder+'/gt_no_pose.sfm',
-            uid=[]
+            description='Sfm file containing the ground truth views and intrinsics (without poses).',
+            value=desc.Node.internalFolder+'/gt_no_pose.sfm'
         ),
         desc.File(
             name='groundTruth',
             label='Ground truth',
-            description='Sfm file containing the ground truth views, intrinsics and poses',
+            description='Sfm file containing the ground truth views, intrinsics and poses.',
             value=desc.Node.internalFolder+'/gt.sfm',
-            uid=[]
         ),
     ]
 

--- a/mrrs/nodes/stereo_photometry/MS_PS/MS_PS.py
+++ b/mrrs/nodes/stereo_photometry/MS_PS/MS_PS.py
@@ -27,7 +27,6 @@ The lighting conditions are assumed to be known.
             label="SfMData",
             description="Input SfMData file.",
             value="",
-            uid=[0]
         ),
         desc.File(
             name="pathToJSONLightFile",
@@ -35,7 +34,6 @@ The lighting conditions are assumed to be known.
             description="Path to a JSON file containing the lighting information.\n"
                         "If empty, .txt files are expected in the image folder.",
             value="defaultJSON.txt",
-            uid=[0]
         )
     ]
 
@@ -45,6 +43,5 @@ The lighting conditions are assumed to be known.
             label="Output Folder",
             description="Path to the output folder.",
             value=desc.Node.internalFolder,
-            uid=[],
         ),
     ]

--- a/mrrs/nodes/stereo_photometry/Uni_MS_PS/Uni_MS_PS.py
+++ b/mrrs/nodes/stereo_photometry/Uni_MS_PS/Uni_MS_PS.py
@@ -26,7 +26,6 @@ Reconstruction using Photometric Stereo. A normal map is evaluated from several 
             label="SfMData",
             description="Input SfMData file.",
             value="",
-            uid=[0]
         )
     ]
 
@@ -36,6 +35,5 @@ Reconstruction using Photometric Stereo. A normal map is evaluated from several 
             label="Output Folder",
             description="Path to the output folder.",
             value=desc.Node.internalFolder,
-            uid=[],
         )
     ]

--- a/mrrs/nodes/utils/CalibTransform.py
+++ b/mrrs/nodes/utils/CalibTransform.py
@@ -84,17 +84,15 @@ class CalibTransform(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='transform',
             label='Tranform',
-            description='Transformation to apply to the calib',
+            description='Transformation to apply to the calib.',
             values=transforms_names,
             value=transforms_names[0],
             exclusive=True,
-            uid=[0],
             joinChar=',',
         ),
 
@@ -104,17 +102,15 @@ class CalibTransform(desc.Node):
             label='Parameter',
             description='',
             value='[[1,0,0], [0,1,0], [0,0,1]]',
-            uid=[0],
         ),
 
     desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
 
     ]
@@ -123,9 +119,8 @@ class CalibTransform(desc.Node):
         desc.File(
             name='outputSfMData',
             label='Output',
-            description='Output sfm data',
+            description='Output SfM data.',
             value=os.path.join(desc.Node.internalFolder, "sfm.sfm"),
-            uid=[]
         )
     ]
 

--- a/mrrs/nodes/utils/ComputeNormals.py
+++ b/mrrs/nodes/utils/ComputeNormals.py
@@ -25,23 +25,20 @@ class ComputeNormals(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
         desc.File(
             name="depthMapsFolder",
             label="DepthMaps Folder",
-            description="Input depth maps folder",
+            description="Input depth maps folder.",
             value="",
-            uid=[0],
         ),
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[],
         ),
     ]
 
@@ -51,7 +48,6 @@ class ComputeNormals(desc.Node):
             label='Output normal Folder',
             description='Output folder for refined depth maps.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='normals',
@@ -59,7 +55,6 @@ class ComputeNormals(desc.Node):
             description='Generated depth maps.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>.exr',
-            uid=[],
             group='', # do not export on the command line
         ),
     ]

--- a/mrrs/nodes/utils/ConvertImages.py
+++ b/mrrs/nodes/utils/ConvertImages.py
@@ -30,17 +30,15 @@ class ConvertImages(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='outputFormat',
             label='Output Format',
-            description='''Output format to be used''',
+            description='''Output format to be used.''',
             value='.png',
             values=['.png', '.jpg', '.exr'],
             exclusive=True,
-            uid=[0],
         ),
 
         #TODO: mode auto
@@ -50,34 +48,30 @@ class ConvertImages(desc.Node):
             description='Resample by a given factor along the x dim.',
             value=1,
             range=(0, 100, 1),
-            uid=[0],
         ),
 
         desc.IntParam(
             name='maxWidth',
             label='Maximum Width',
-            description='Will resize to the max width (keep the aspect ratio)',
+            description='Will resize to the max width (keep the aspect ratio).',
             value=1000000000,
             range=(0, 4096, 1),
-            uid=[0],
         ),
 
         desc.IntParam(
             name='forceWidth',
             label='Force Width',
-            description='Will resize to the with by paddign or croping, if != 0',
+            description='Will resize to the width by padding or cropping, if != 0.',
             value=0,
             range=(0, 4096, 1),
-            uid=[0],
         ),
 
         desc.IntParam(
             name='forceHeight',
             label='Force Height',
-            description='Will resize to the height by paddign or croping, if != 0',
+            description='Will resize to the height by padding or cropping, if != 0.',
             value=0,
             range=(0, 4096, 1),
-            uid=[0],
         ),
 
 
@@ -85,51 +79,45 @@ class ConvertImages(desc.Node):
         desc.BoolParam(
             name='mergeInterinsics',
             label='mergeInterinsics',
-            description='Will merge all intrinsics by taking the first one',
+            description='Will merge all intrinsics by taking the first one.',
             value=False,
-            uid=[0],
         ),
 
         desc.BoolParam(
             name='autoRotate',
             label='autoRotate',
-            description='Rotates the frames using the exif flag',
+            description='Rotates the frames using the EXIF flag.',
             value=True,
-            uid=[0],
         ),
 
         desc.BoolParam(
             name='convertSRGB',
             label='convertSRGB',
-            description='Will convert to srgb',
+            description='Will convert to srgb.',
             value=True,
-            uid=[0],
         ),
 
         desc.BoolParam(
             name='renameSequence',
             label='Rename Sequence',
-            description='Renames the frames by order',
+            description='Renames the frames by order.',
             value=False,
-            uid=[0],
         ),
 
         desc.BoolParam(
             name='autoPixelRatio',
             label='autoPixelRatio',
-            description='Will automatically set pixel ratio (will overwrite resample)',
+            description='Will automatically set pixel ratio (will overwrite resample).',
             value=True,
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         )
     ]
 
@@ -139,14 +127,12 @@ class ConvertImages(desc.Node):
             label='Output Folder',
             description='Output folder for converted images.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='outputSfMData',
             label='SfMData',
-            description='Path to the output sfmdata file',
+            description='Path to the output sfmdata file.',
             value=desc.Node.internalFolder + 'sfm.sfm',
-            uid=[],
         )
         ]
 

--- a/mrrs/nodes/utils/CopyData.py
+++ b/mrrs/nodes/utils/CopyData.py
@@ -20,35 +20,31 @@ class CopyData(desc.Node):
         desc.File(
             name='inputFolder',
             label='Input Folder',
-            description='''Get the input folder from any node output''',
+            description='''Get the input folder from any node output.''',
             value='',
-            uid=[0],
         ),
 
         desc.StringParam(
             name='inputFile',
             label='Input File',
-            description='''Input file to copy''',
+            description='''Input file to copy.''',
             value='',
-            uid=[0],
         ),
 
         desc.StringParam(
             name='outputName',
             label='outputName',
-            description='''Output name''',
+            description='''Output name.''',
             value='',
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -56,9 +52,8 @@ class CopyData(desc.Node):
         desc.File(
             name='outputFile',
             label='Output File',
-            description='Path to the output file',
+            description='Path to the output file.',
             value=lambda attr: os.path.join(desc.Node.internalFolder, os.path.basename(attr.node.inputFile.value) if attr.node.outputName.value =="" else attr.node.outputName.value),
-            uid=[],
         ),
 
     ]

--- a/mrrs/nodes/utils/CutSfm.py
+++ b/mrrs/nodes/utils/CutSfm.py
@@ -21,7 +21,6 @@ class CutSfm(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
     
@@ -30,36 +29,31 @@ class CutSfm(desc.Node):
             label='Parameter',
             description='',
             value='',
-            uid=[0],
         ),
 
     desc.BoolParam(
             name='removeImagePath',
             label='removeImagePath',
-            description='Will remove the fullpath to images',
+            description='Will remove the fullpath to images.',
             value=True,
-            uid=[0],
         ),
 
     desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
-
     ]
 
     outputs = [
         desc.File(
             name='outputSfMData',
             label='Output',
-            description='Output sfm data',
+            description='Output SfM data.',
             value=os.path.join(desc.Node.internalFolder, "sfm.sfm"),
-            uid=[]
         )
     ]
 

--- a/mrrs/nodes/utils/DepthMapTransform.py
+++ b/mrrs/nodes/utils/DepthMapTransform.py
@@ -115,36 +115,32 @@ class DepthMapTransform(desc.Node):
             label='SfMData',
             description='SfMData file.',
             value='',
-            uid=[0],
         ),
 
         desc.File(
             name="depthMapsFolder",
             label="DepthMaps Folder",
-            description="Input depth maps folder",
+            description="Input depth maps folder.",
             value="",
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='transform',
             label='Tranform',
-            description='Transformation to apply to the depth maps',
+            description='Transformation to apply to the depth maps.',
             values=['meshroom2normal', 'normal2meshroom', 'id'],#TODO: project?
             value='meshroom2normal',
             exclusive=True,
-            uid=[0],
             joinChar=',',
         ),
 
         desc.ChoiceParam(
                 name='verboseLevel',
                 label='Verbose Level',
-                description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+                description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
                 value='info',
                 values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
                 exclusive=True,
-                uid=[0],
             ),
 
     ]
@@ -155,7 +151,6 @@ class DepthMapTransform(desc.Node):
             label='Output',
             description='Output folder for generated results.',
             value=desc.Node.internalFolder,
-            uid=[],
         ),
         desc.File(
             name='depth',
@@ -163,7 +158,6 @@ class DepthMapTransform(desc.Node):
             description='Generated depth maps.',
             semantic='image',
             value=desc.Node.internalFolder + '<VIEW_ID>_depthMap.exr',
-            uid=[],
             group='',
         ),
     ]

--- a/mrrs/nodes/utils/ExecuteCmdConda.py
+++ b/mrrs/nodes/utils/ExecuteCmdConda.py
@@ -16,7 +16,6 @@ class ExecuteCmdConda(CondaNode):
             label='commandLine',
             description=''' ''',
             value='echo "Hello"',
-            uid=[0],
             ),
 
         desc.StringParam(
@@ -24,17 +23,15 @@ class ExecuteCmdConda(CondaNode):
             label='condaEnv',
             description='''''',
             value='',
-            uid=[0],
             group=''
             ),
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 

--- a/mrrs/nodes/utils/InjectSfmData.py
+++ b/mrrs/nodes/utils/InjectSfmData.py
@@ -22,37 +22,33 @@ class InjectSfmData(desc.Node):
         desc.File(
             name='sourceSfmData',
             label='Source SfmData',
-            description='Input sfm file containing the fields to be injected in target sfmdata.',
+            description='Input sfm file containing the fields to be injected in target SfMData.',
             value=desc.Node.internalFolder,
-            uid=[0],
         ),
 
         desc.File(
             name='targetSfmData',
             label='Target SfmData',
-            description='Input sfm file containing the sfm data to be injected with fata from the source sfm data.',
+            description='Input SfM file containing the SfM data to be injected with data from the source SfMData.',
             value=desc.Node.internalFolder,
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='exportedFields',
             label='Exported Fields',
-            description='''Fields of the .sfm to export''',
+            description='''Fields of the .sfm to export.''',
             value=['structure'],
             values=['poses', 'views' ,'intrinsics', 'structure', 'version', 'featuresFolders', 'matchesFolders'],
             exclusive=False,
-            uid=[0],
         ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -60,9 +56,8 @@ class InjectSfmData(desc.Node):
         desc.File(
             name='outputSfMData',
             label='SfMData',
-            description='Path to the output sfmdata file',
+            description='Path to the output SfMData file.',
             value=desc.Node.internalFolder + 'sfm.sfm',
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/utils/MeshTransform.py
+++ b/mrrs/nodes/utils/MeshTransform.py
@@ -22,21 +22,18 @@ class MeshTransform(desc.Node):#FIXME: abstract this Dataset, scan folder etc...
             label='Input mesh',
             description='Input mesh.',
             value=desc.Node.internalFolder,
-            uid=[0],
         ),
         desc.File(
             name='inputTransform',
             label='Input transform',
             description='Input transform.',
             value='',
-            uid=[0],
         ),
         desc.BoolParam(
             name='flipCG_CV',
             label='flipCG_CV',
-            description='Flip from a CG to a CV cs or vice versa',
+            description='Flip from a CG to a CV cs or vice versa.',
             value=False,
-            uid=[0],
         ),
         desc.FloatParam(
             name='addGaussianNoise',
@@ -44,27 +41,24 @@ class MeshTransform(desc.Node):#FIXME: abstract this Dataset, scan folder etc...
             description='Add Gaussian Noise to the mesh vertices.',
             value=-1.0,
             range=(-1.0, 100.0, 1.0),
-            uid=[0],
-            ),
+        ),
 
         # desc.ChoiceParam(
         #     name='extention',
         #     label='Extention',
-        #     description='''File format for the ouptut mesh ''',
+        #     description='''File format for the ouptut mesh.''',
         #     value='.ply',
         #     values=['.ply', '.obj'],
         #     exclusive=True,
-        #     uid=[0],
         # ),
 
         desc.ChoiceParam(
             name='verboseLevel',
             label='Verbose Level',
-            description='''verbosity level (fatal, error, warning, info, debug, trace).''',
+            description='''Verbosity level (fatal, error, warning, info, debug, trace).''',
             value='info',
             values=['fatal', 'error', 'warning', 'info', 'debug', 'trace'],
             exclusive=True,
-            uid=[0],
         ),
     ]
 
@@ -74,7 +68,6 @@ class MeshTransform(desc.Node):#FIXME: abstract this Dataset, scan folder etc...
             label='Output mesh',
             description='Output Mesh.',
             value=desc.Node.internalFolder + 'mesh.ply',#pb: not extention!!! variable output
-            uid=[],
         ),
     ]
 

--- a/mrrs/nodes/utils/Seq2Video.py
+++ b/mrrs/nodes/utils/Seq2Video.py
@@ -17,14 +17,12 @@ class Seq2Video(desc.CommandLineNode):
             label='imagesFolder',
             description=''' ''',
             value='',
-            uid=[0],
             ),
         desc.StringParam(
             name='pattern',
             label='pattern',
             description=''' ''',
             value='*.png',
-            uid=[0],
             ),
         desc.FloatParam(
             name='framerate',
@@ -32,14 +30,12 @@ class Seq2Video(desc.CommandLineNode):
             description=''' ''',
             value=25.0,
             range=(1.0, 3000.0, 1.0),
-            uid=[0],
             ),
         desc.StringParam(
             name='videoFormat',
             label='videoFormat',
             description=''' ''',
             value='.mp4',
-            uid=[0],
             ),
     ]
 
@@ -49,6 +45,5 @@ class Seq2Video(desc.CommandLineNode):
             label='Output Video',
             description='''  ''',
             value=os.path.join(desc.Node.internalFolder, 'video'),
-            uid=[],
             ),
     ]


### PR DESCRIPTION
Following https://github.com/alicevision/Meshroom/pull/2523, the argument in node descriptions to state whether an attribute contributes to the node's UID computation changes from `uid=[0]`/`uid=[]` to `invalidate=True`/`invalidate=False`.

By default, all attributes are set to `invalidate=True`, and output attributes, which should never take part to the UID computation, are handled without the need to specify `invalidate=False`.

This PR updates all the Meshroom nodes accordingly.

N.B: this PR should not be merged until https://github.com/alicevision/Meshroom/pull/2523 has been integrated into `develop`.